### PR TITLE
Configure database and define user and session entities

### DIFF
--- a/src/main/kotlin/com/interviewmate/Application.kt
+++ b/src/main/kotlin/com/interviewmate/Application.kt
@@ -1,7 +1,10 @@
 package com.interviewmate
 
+import com.interviewmate.repository.UserRepository
+import org.springframework.boot.CommandLineRunner
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
 
 /**
  * Main Spring Boot application class for InterviewMate backend service.
@@ -16,7 +19,13 @@ import org.springframework.boot.runApplication
  * - Free tier with limited question access
  */
 @SpringBootApplication
-class InterviewMateApplication
+class InterviewMateApplication {
+    @Bean
+    fun initDatabase(userRepository: UserRepository) = CommandLineRunner {
+        val userCount = userRepository.count()
+        println("Database ready: user table rows = $userCount")
+    }
+}
 
 fun main(args: Array<String>) {
     runApplication<InterviewMateApplication>(*args)


### PR DESCRIPTION
Adds JPA entities and repositories for User and InterviewSession, and a database initialization check to configure the data layer.

---
<a href="https://cursor.com/background-agent?bcId=bc-3debb5e7-586f-4fea-b333-904f2a97b44f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3debb5e7-586f-4fea-b333-904f2a97b44f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

