### PR TITLE
Configure database and define user and session entities

### DIFF
--- a/src/main/kotlin/com/interviewmate/Application.kt
+++ b/src/main/kotlin/com/interviewmate/Application.kt
@@ -2,6 +2,9 @@ package com.interviewmate
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.boot.CommandLineRunner
+import org.springframework.context.annotation.Bean
+import com.interviewmate.repository.UserRepository
 
 /**
  * Main Spring Boot application class for InterviewMate backend service.
@@ -16,7 +19,13 @@ import org.springframework.boot.runApplication
  * - Free tier with limited question access
  */
 @SpringBootApplication
-class InterviewMateApplication
+class InterviewMateApplication {
+    @Bean
+    fun initDatabase(userRepository: UserRepository) = CommandLineRunner {
+        val userCount = userRepository.count()
+        println("Database ready: user table rows = $userCount")
+    }
+}
 
 fun main(args: Array<String>) {
     runApplication<InterviewMateApplication>(*args)


### PR DESCRIPTION
Adds core JPA entities (`User`, `InterviewSession`), Spring Data JPA repositories, and a database initialization check.

This sets up the foundational data layer for the InterviewMate application, allowing persistence of user and interview session data. The `CommandLineRunner` bean verifies database connectivity and schema auto-creation on application startup.

---
<a href="https://cursor.com/background-agent?bcId=bc-596f7e68-8b38-4f79-a466-a76556cfd95c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-596f7e68-8b38-4f79-a466-a76556cfd95c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

